### PR TITLE
Option to preserve former tab data as long as the app stays open

### DIFF
--- a/UnitedSets/App.xaml.cs
+++ b/UnitedSets/App.xaml.cs
@@ -49,6 +49,7 @@ public partial class App : Application
         var services = new ServiceCollection();
 
         services.AddSingleton<SettingsService>();
+		services.AddSingleton<PreservedTabDataService>();
 
         return services.BuildServiceProvider();
     }

--- a/UnitedSets/Classes/Cell.APIs.cs
+++ b/UnitedSets/Classes/Cell.APIs.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls;
 using System.ComponentModel;
 using System.Linq;
 using System;
@@ -33,7 +33,7 @@ partial class Cell
     
     Cell[] CraeteNCells(int Amount)
     {
-        return (from _ in 0..Amount select new Cell(MainWindow, null, null, default)).ToArray();
+		return Enumerable.Range(0,Amount).Select(_ => new Cell(MainWindow, null, null, default)).ToArray();
     }
 
     public Cell DeepClone(MainWindow NewWindow)

--- a/UnitedSets/Classes/Tabs/CellTab.Implement.cs
+++ b/UnitedSets/Classes/Tabs/CellTab.Implement.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -48,7 +48,10 @@ partial class CellTab
         //window.Tabs.Add(new CellTab(window, MainCell.DeepClone(window)));
         foreach (var cell in MainCell.AllSubCells)
         {
-            if (cell.CurrentCell is HwndHost hwndHost) hwndHost.DetachAndDispose();
+			if (cell.CurrentCell is HwndHost hwndHost) {
+				SaveTabData(hwndHost);
+				hwndHost.DetachAndDispose();
+			}
         }
         _IsDisposed = true;
         //window.Activate();

--- a/UnitedSets/Classes/Tabs/HwndHostTab.Implement.APIs.cs
+++ b/UnitedSets/Classes/Tabs/HwndHostTab.Implement.APIs.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Xaml.Media.Imaging;
 using System;
 using System.Drawing;
 using System.Threading.Tasks;
@@ -27,6 +27,7 @@ partial class HwndHostTab
     public override async void DetachAndDispose(bool JumpToCursor)
     {
         var Window = this.Window;
+		SaveTabData(HwndHost);
         await HwndHost.DetachAndDispose();
         PInvoke.GetCursorPos(out var CursorPos);
         if (JumpToCursor && !HwndHost.NoMovingMode)

--- a/UnitedSets/Classes/Tabs/HwndHostTab.cs
+++ b/UnitedSets/Classes/Tabs/HwndHostTab.cs
@@ -41,7 +41,9 @@ public partial class HwndHostTab : TabBase
         HwndHost.Closed += Closed;
         _Title = DefaultTitle;
         UpdateAppIcon();
-    }
+		LoadTabData(HwndHost);
+
+	}
 
     async void UpdateAppIcon()
     {

--- a/UnitedSets/Classes/Tabs/TabBase.Static.cs
+++ b/UnitedSets/Classes/Tabs/TabBase.Static.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -16,7 +16,10 @@ partial class TabBase
     static readonly SynchronizedCollection<TabBase> AllTabs = new();
     static readonly WindowClass UnitedSetsSwitcherWindowClass;
 
-    static readonly SettingsService Settings
+	static readonly PreservedTabDataService PreservedTabService
+		= App.Current.Services.GetService<PreservedTabDataService>() ?? throw new InvalidOperationException("PreservedTabDataService Init Failed");
+
+	static readonly SettingsService Settings
         = App.Current.Services.GetService<SettingsService>() ?? throw new InvalidOperationException("Settings Init Failed");
 
     static TabBase()

--- a/UnitedSets/Classes/Tabs/TabBase.cs
+++ b/UnitedSets/Classes/Tabs/TabBase.cs
@@ -1,5 +1,11 @@
-﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml.Controls;
+using System;
 using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using UnitedSets.Services;
+using WinUI3HwndHostPlus;
 
 namespace UnitedSets.Classes.Tabs;
 
@@ -12,4 +18,32 @@ public abstract partial class TabBase : INotifyPropertyChanged
         this.IsSwitcherVisible = IsSwitcherVisible;
         InitSwitcher();
     }
+	protected void SaveTabData(HwndHost host) {
+		if (!Settings.TempState)
+			return;
+		GetWindowThreadProcessId(host.GetRawHWND(), out var pid);
+		if (pid == 0)
+			return;
+		var data = new PreservedTabData(host.GetRawHWND().Value, pid) { CustomTitle = CustomTitle, Borderless = host.BorderlessWindow, CropEnabled = host.ActivateCrop, CropRect = new CropRect(host.CropLeft, host.CropTop, host.CropRight, host.CropBottom) };
+		PreservedTabService.SaveTab(data);
+	}
+	protected virtual void LoadTabData(HwndHost host) {
+		if (!Settings.TempState)
+			return;
+		GetWindowThreadProcessId(host.GetRawHWND(), out var pid);
+		if (pid == 0)
+			return;
+		var data = PreservedTabService.LookupTab(pid, host.GetRawHWND().Value);
+		if (data == null)
+			return;
+		CustomTitle = data.CustomTitle;
+		host.BorderlessWindow = data.Borderless;
+		host.ActivateCrop = data.CropEnabled;
+		host.CropLeft = data.CropRect.Left;
+		host.CropTop = data.CropRect.Top;
+		host.CropRight = data.CropRect.Right;
+		host.CropBottom = data.CropRect.Bottom;
+	}
+	[DllImport("user32.dll", SetLastError = true)]
+	static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 }

--- a/UnitedSets/Services/PreservedTabDataService.cs
+++ b/UnitedSets/Services/PreservedTabDataService.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Windows.Foundation;
+
+namespace UnitedSets.Services {
+	public class PreservedTabData {
+		public PreservedTabData(IntPtr HwndID, uint pid) {
+			this.HwndID = HwndID;
+			this.pid = pid;
+		}
+		public IntPtr HwndID;
+		public uint pid;
+		public DateTime LastDetached = DateTime.Now;
+
+		public string CustomTitle;
+		public bool Borderless;
+		public bool CropEnabled;
+		public CropRect CropRect;
+
+	}
+	public class CropRect {
+		public int Left; public int Top; public int Right; public int Bottom;
+		public CropRect(int left, int top, int right, int bottom) {
+			this.Left = left;
+			this.Top = top;
+			this.Right = right;
+			this.Bottom = bottom;
+		}
+	}
+	internal class PreservedTabDataService {
+		public ConcurrentDictionary<IntPtr, PreservedTabData> TabData=new();
+		public void SaveTab(PreservedTabData data) {
+			if (data.Borderless || data.CropEnabled || String.IsNullOrWhiteSpace( data.CustomTitle) == false)//only save if we have actual data--=-=-=
+				TabData[data.HwndID] = data;
+		}
+		public PreservedTabData? LookupTab(uint pid, IntPtr hwnd) {
+			if (!TabData.TryGetValue(hwnd, out var data))
+				return null;
+			if (data.pid != pid) {
+				TabData.TryRemove(hwnd, out _);
+				return null;
+			}
+			return data;
+		}
+	}
+}

--- a/UnitedSets/Services/SettingsService.cs
+++ b/UnitedSets/Services/SettingsService.cs
@@ -20,7 +20,9 @@ public partial class SettingsService : ObservableObject
             {
                 if (exitOnClose != ExitOnClose)
                     SetProperty(ref exitOnClose, ExitOnClose);
-                Thread.Sleep(2000);
+				if (tempState != TempState)
+					SetProperty(ref tempState, TempState);
+				Thread.Sleep(2000);
             }
         })
         {
@@ -59,7 +61,13 @@ private static readonly ApplicationDataContainer Settings = ApplicationData.Curr
 	[Property(CustomGetExpression = "(bool)(Settings.Values[\"ExitOnClose\"] ?? true)", OnChanged = nameof(ExitOnCloseChanged))]
     private bool exitOnClose = (bool)(Settings.Values["ExitOnClose"] ?? true);
     private void ExitOnCloseChanged() => Settings.Values["ExitOnClose"] = exitOnClose;
-    SettingsWindow s_window;
+
+	[Property(CustomGetExpression = "(bool)(Settings.Values[" + nameof(TEMP_STATE_SETTING_NAME) + "] ?? false)", OnChanged = nameof(TempStateChanged))]
+	private bool tempState = (bool)(Settings.Values[TEMP_STATE_SETTING_NAME] ?? false);
+	private void TempStateChanged() => Settings.Values[TEMP_STATE_SETTING_NAME] = exitOnClose;
+	private const string TEMP_STATE_SETTING_NAME = "TempState";
+
+	SettingsWindow s_window;
     [RelayCommand]
     public void LaunchSettings()
     {

--- a/UnitedSets/UnitedSets.csproj
+++ b/UnitedSets/UnitedSets.csproj
@@ -20,6 +20,7 @@
 		<GenerateTestArtifacts>True</GenerateTestArtifacts>
 		<AppxBundle>Never</AppxBundle>
 		<HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
+		<LangVersion>preview</LangVersion>
 		<Configurations>Debug;Release;DebugUnpackaged</Configurations>
 	</PropertyGroup>
 	<ItemGroup>

--- a/UnitedSets/Windows/Flyout/Modules/Tab Settings/BasicTabFlyoutModule.xaml
+++ b/UnitedSets/Windows/Flyout/Modules/Tab Settings/BasicTabFlyoutModule.xaml
@@ -1,4 +1,4 @@
-﻿<Grid
+<Grid
     x:Class="UnitedSets.Windows.Flyout.Modules.BasicTabFlyoutModule"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -27,6 +27,7 @@
                     </Button>
                 </StackPanel>
             </Grid>
-        </StackPanel>
+			<Button Click="DetachWindow">Detach Window</Button>
+		</StackPanel>
     </Border>
 </Grid>

--- a/UnitedSets/Windows/Flyout/Modules/Tab Settings/BasicTabFlyoutModule.xaml.cs
+++ b/UnitedSets/Windows/Flyout/Modules/Tab Settings/BasicTabFlyoutModule.xaml.cs
@@ -1,11 +1,13 @@
-﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using UnitedSets.Classes.Tabs;
 using EasyCSharp;
+using WinUI3HwndHostPlus;
+using System;
+
 namespace UnitedSets.Windows.Flyout.Modules;
 
-public sealed partial class BasicTabFlyoutModule
-{
+public sealed partial class BasicTabFlyoutModule : IWindowFlyoutModule {
     public BasicTabFlyoutModule(TabBase TabBase)
     {
         this.TabBase = TabBase;
@@ -13,7 +15,17 @@ public sealed partial class BasicTabFlyoutModule
     }
     readonly TabBase TabBase;
 
-    [Event(typeof(TextChangedEventHandler))]
+	public event Action RequestClose;
+
+	[Event(typeof(RoutedEventHandler))]
+	void DetachWindow() {
+
+
+		TabBase.DetachAndDispose();
+		RequestClose?.Invoke();
+	}
+
+	[Event(typeof(TextChangedEventHandler))]
     private void TabNameTextBoxChanged()
     {
         TabBase.CustomTitle = TabNameTextBox.Text;
@@ -24,4 +36,8 @@ public sealed partial class BasicTabFlyoutModule
     {
         TabNameTextBox.Text = "";
     }
+
+	public void OnActivated() {
+		
+	}
 }

--- a/UnitedSets/Windows/Flyout/Modules/Tab Settings/ModifyWindowFlyoutModule.xaml
+++ b/UnitedSets/Windows/Flyout/Modules/Tab Settings/ModifyWindowFlyoutModule.xaml
@@ -101,7 +101,6 @@
             </Grid>
             <StackPanel HorizontalAlignment="Center" Orientation="Horizontal" Spacing="8">
                 <Button Click="CloseWindow">Close Window</Button>
-                <Button Click="DetachWindow">Detach Window</Button>
             </StackPanel>
             <Button HorizontalAlignment="Center" Click="OpenWindowLocation">Open Window file location</Button>
         </StackPanel>

--- a/UnitedSets/Windows/Flyout/Modules/Tab Settings/ModifyWindowFlyoutModule.xaml.cs
+++ b/UnitedSets/Windows/Flyout/Modules/Tab Settings/ModifyWindowFlyoutModule.xaml.cs
@@ -93,15 +93,11 @@ public sealed partial class ModifyWindowFlyoutModule : IWindowFlyoutModule
         await HwndHost.HostedWindow.TryCloseAsync();
         RequestClose?.Invoke();
     }
-    [Event(typeof(RoutedEventHandler))]
-    void DetachWindow()
-    {
-        HwndHost.DetachAndDispose();
-        RequestClose?.Invoke();
-    }
+    
 
     public void OnActivated()
     {
         
     }
+
 }

--- a/UnitedSets/Windows/SettingsWindow.xaml
+++ b/UnitedSets/Windows/SettingsWindow.xaml
@@ -1,4 +1,4 @@
-﻿<winex:WindowEx 
+<winex:WindowEx 
     xmlns:winex="using:WinUIEx" 
     x:Class="UnitedSets.Windows.SettingsWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -10,6 +10,12 @@
     MinWidth="890"
     mc:Ignorable="d">
     <Grid>
+		<Grid.Resources>
+			<Style TargetType="ToggleSwitch">
+				<Setter Property="OnContent" Value="On" />
+				<Setter Property="OffContent" Value="Off" />
+			</Style>
+		</Grid.Resources>
         <Border x:Name="AppTitleBar"
                 IsHitTestVisible="True"
                 VerticalAlignment="Top"
@@ -51,9 +57,17 @@
                         <settings:SettingsBlockControl.Icon>
                             <icons:FluentIconElement VerticalAlignment="Center" Symbol="Delete24"/>
                         </settings:SettingsBlockControl.Icon>
-                        <ToggleSwitch IsOn="{x:Bind Settings.ExitOnClose, Mode=TwoWay}" Style="{ThemeResource GlowSwitch}" OnContent="On" HorizontalAlignment="Right" OffContent="Off"/>
+                        <ToggleSwitch IsOn="{x:Bind Settings.ExitOnClose, Mode=TwoWay}" Style="{ThemeResource GlowSwitch}" HorizontalAlignment="Right" />
                     </settings:SettingsBlockControl>
-                    <settings:SettingsBlockControl Title="About" Margin="2" Description="Credits, links and information">
+
+					<settings:SettingsBlockControl Title="Temp save state when detached" Margin="2" Description="Remember title changes and crop settings for windows when detached to re-apply on re-attach">
+						<settings:SettingsBlockControl.Icon>
+							<icons:FluentIconElement VerticalAlignment="Center" Symbol="Archive24"/>
+						</settings:SettingsBlockControl.Icon>
+						<ToggleSwitch IsOn="{x:Bind Settings.TempState, Mode=TwoWay}" Style="{ThemeResource GlowSwitch}" HorizontalAlignment="Right" />
+					</settings:SettingsBlockControl>
+
+					<settings:SettingsBlockControl Title="About" Margin="2" Description="Credits, links and information">
                         <settings:SettingsBlockControl.Icon>
                             <icons:FluentIconElement VerticalAlignment="Center" Symbol="Info24"/>
                         </settings:SettingsBlockControl.Icon>

--- a/WinUI3HwndHostPlus/HwndHost.Properties.cs
+++ b/WinUI3HwndHostPlus/HwndHost.Properties.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml;
 using System;
 using Microsoft.UI.Windowing;
 using System.Collections.Generic;
@@ -29,6 +29,7 @@ partial class HwndHost
 
     [Property(SetVisibility = GeneratorVisibility.DoNotGenerate)]
     readonly WindowEx _HostedWindow;
+	public Windows.Win32.Foundation.HWND GetRawHWND() => _HostedWindow.Handle;
 
     [Property(OnChanged = nameof(IsWindowVisibleChanged))]
     bool _IsWindowVisible;


### PR DESCRIPTION
Do not merge this.

This is some initial state framework to allow saving the hwnd settings between attaching and detaching.  It is only stored in memory for the life of the app, uses the HWND id itself to decide if the same window (with a pid check as well in case of reuse).   I am sure once rules/etc come along it can be extended further.  

There are two problems one of which is pretty easy to resolve the other I am less sure on.   The less-obvious one is the multi-united sets instance problem.   If you have two UnitedSets apps running detach a hwnd from one and attach to another it would not preserve state as they dont  have communication between them.  I think from a stability point not having one single executable manage multiple windows is probably a good idea but to fix this will mean either storing that data in a durable fashion (ie to disk)  syncing that data with other instances when changed (what happens when a new instance starts up?) or allowing another instance to ask us if we know about HWND X.  The last isn't bad but would result in some delay on attach which is more jarring to the user (although could do async).   For now maybe it is acceptable that multi-instances won't have the shared state.  


I ran into a problem I am not sure the best solution on.   Under the tab options flyout there is a "Detach Tab" button.  Now this calls detach on the hwndhost directly rather than calling the detach method on the tab itself.   I think we should always be calling detach on the actual tab, but wasn't sure the best way to do so.  I thought about passing the tab in, but the problem is: https://github.com/FireCubeStudios/UnitedSets/blob/4f59eb97e136f56e49dd50e1ce9e646bc453b4b9/UnitedSets/Windows/Flyout/Modules/Tab%20Settings/MultiWindowModifyFlyoutModule.xaml.cs#L24-L27

has no reference to the tab itself.

Of course looking at this it would seem like this is gearing up for the split / multi-pane support.  I think there is value in potentially doing multi-pane at a per app instance rather than per tab so tabs would still be independent (just repping a slice of the pane).  Assuming though a tab is shared by multiple panes/hwndhosts then a potential solution would be:
hwndhost has some reference to its parent tab,  this would allow you to get the tab name for example.   For my restore code if the incoming hwnd had a custom name previously and the current tab does not then it overrides the custom name, otherwise it leaves it alone.

To show POC I moved detach tab to under the display name but clearly not what one would want in the app itself

Open for direction and can update the PR form there.