### PR TITLE
Don't try to unregister events that aren't hooked

### DIFF
--- a/WindowHoster/WinEvents.cs
+++ b/WindowHoster/WinEvents.cs
@@ -35,9 +35,12 @@ public static class WinEvents
             if (newHandler is null)
             {
                 registeredWindow.Remove(type);
-                var disposable = UnhookFuncs[type];
-                UnhookFuncs.Remove(type);
-                disposable.Dispose();
+                if (UnhookFuncs.ContainsKey(type))
+                {
+                    var disposable = UnhookFuncs[type];
+                    UnhookFuncs.Remove(type);
+                    disposable.Dispose();
+                }
             }
             else
                 registeredWindow[type] = newHandler;


### PR DESCRIPTION
Not sure if this is a race condition of a sign of a problem elsewhere but was getting called with events we were not hooked to.