### PR TITLE
Fix crash with splitpane when no children exists

### DIFF
--- a/UnitedSets/XamlToolsStuff/UI/Layout/EzRelativeStackPanel.cs
+++ b/UnitedSets/XamlToolsStuff/UI/Layout/EzRelativeStackPanel.cs
@@ -29,6 +29,8 @@ public partial class EzRelativeStackPanel : Panel
             double Used = 0;
             var childrenAndRS = (from x in Children select (UIElement: x, RelativeSize: GetRelativeSize(x))).ToArray();
             var totalRS = childrenAndRS.Sum(x => x.RelativeSize);
+            if (totalRS == 0)
+                return new Size(0,0);            
             var ChildrenCount = Children.Count;
             var finalOrientedSize = ToOrientedSize(finalSize);
             var Multipier = finalOrientedSize.Adaptive / totalRS;


### PR DESCRIPTION
Does not fix splitpane but does prevent it from throwing a UE otherwise divide by 0 and lots of things that can't work.